### PR TITLE
Fix `out` not being captured and restricted access to System.exit and others

### DIFF
--- a/src/main/java/org/togetherjava/discord/server/BotUtils.java
+++ b/src/main/java/org/togetherjava/discord/server/BotUtils.java
@@ -4,22 +4,20 @@ import sx.blah.discord.api.ClientBuilder;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.util.DiscordException;
-import sx.blah.discord.util.MessageBuilder;
 import sx.blah.discord.util.RequestBuffer;
 
 public class BotUtils {
-    public static IDiscordClient buildDiscordClient(String token){
+    public static IDiscordClient buildDiscordClient(String token) {
         return new ClientBuilder()
                 .withToken(token)
                 .build();
     }
 
-    public static void sendMessage(IChannel channel, String message){
+    public static void sendMessage(IChannel channel, String message) {
         RequestBuffer.request(() -> {
-            try{
+            try {
                 channel.sendMessage(message);
-            }
-            catch(DiscordException ex){
+            } catch (DiscordException ex) {
                 JShellBot.log.error("Message could not be sent with error: ");
                 JShellBot.log.trace(ex.getStackTrace());
             }

--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -19,7 +19,7 @@ public class Config {
      */
     public Config(Path configPath) throws IOException {
         Properties defaults = new Properties();
-        loadFromStream(defaults, getClass().getResourceAsStream("/bot.properties"));
+        loadFromStream(defaults, getClass().getResourceAsStream("/bot.properties.example"));
 
         this.properties = new Properties(defaults);
 

--- a/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
@@ -22,6 +22,11 @@ public class FilteredExecutionControl extends LocalExecutionControl {
         blockPackage("java.lang.reflect");
         blockPackage("java.lang.invoke");
         blockMethod("java.lang.reflect.Method", "invoke");
+        blockMethod("java.lang.System", "exit");
+        blockMethod("java.lang.Thread", "sleep");
+        blockMethod("java.lang.Thread", "wait");
+        blockMethod("java.lang.Thread", "notify");
+        blockMethod("java.lang.Thread", "currentThread");
     }
 
     public void blockMethod(String clazz, String methodName) {
@@ -65,7 +70,7 @@ public class FilteredExecutionControl extends LocalExecutionControl {
                 throw new UnsupportedOperationException("Naughty (class): " + owner);
             }
             if (blockedMethods.contains(new ImmutablePair<>(sanitizeClassName(owner), name))) {
-                throw new UnsupportedOperationException("Naughty (meth): " + owner);
+                throw new UnsupportedOperationException("Naughty (meth): " + owner + "#" + name);
             }
             if (blockedPackages.contains(sanitizeClassName(owner.substring(0, owner.lastIndexOf('/'))))) {
                 throw new UnsupportedOperationException("Naughty (pack): " + owner);

--- a/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlProvider.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlProvider.java
@@ -1,12 +1,22 @@
 package org.togetherjava.discord.server.sandbox;
 
+import jdk.jshell.execution.JdiExecutionControlProvider;
 import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionControlProvider;
 import jdk.jshell.spi.ExecutionEnv;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Map;
 
 public class FilteredExecutionControlProvider implements ExecutionControlProvider {
+
+    private final JdiExecutionControlProvider jdiExecutionControlProvider;
+
+    public FilteredExecutionControlProvider() {
+        jdiExecutionControlProvider = new JdiExecutionControlProvider();
+    }
 
     @Override
     public String name() {
@@ -15,6 +25,35 @@ public class FilteredExecutionControlProvider implements ExecutionControlProvide
 
     @Override
     public ExecutionControl generate(ExecutionEnv env, Map<String, String> parameters) throws Throwable {
-        return new FilteredExecutionControl();
+        ExecutionControl hijackedExecutionControl = jdiExecutionControlProvider.generate(env, parameters);
+        FilteredExecutionControl filteredExecutionControl = new FilteredExecutionControl();
+
+        return (ExecutionControl) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{ExecutionControl.class},
+                new ExecutionControlDelegatingProxy(filteredExecutionControl, hijackedExecutionControl)
+        );
+    }
+
+    private static class ExecutionControlDelegatingProxy implements InvocationHandler {
+        private FilteredExecutionControl target;
+        private ExecutionControl hijackedExecutionControl;
+
+        private ExecutionControlDelegatingProxy(FilteredExecutionControl target, ExecutionControl hijackedExecutionControl) {
+            this.target = target;
+            this.hijackedExecutionControl = hijackedExecutionControl;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if ("load".equals(method.getName())
+                    && method.getParameterTypes()[0] == ExecutionControl.ClassBytecodes.class
+                    && args.length != 0) {
+
+                target.load((ExecutionControl.ClassBytecodes[]) args[0]);
+            }
+
+            return method.invoke(hijackedExecutionControl, args);
+        }
     }
 }


### PR DESCRIPTION
* The `FilteredExecutionControlProvider` created an `ExecutionControl`
  that was not able to correctly set `in` and `out` stream.
  So now it just delegates to the default Jdi provider and wraps around
  it via a `Proxy`
* Fix Thread.sleep, System.exit and others being accessible
* Fix Config.java reading from the wrong default