### PR TITLE
Add a SessionManager to expire sessions, fix the output being null if an exception was thrown

### DIFF
--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -1,6 +1,7 @@
 package org.togetherjava.discord.server;
 
 import jdk.jshell.SnippetEvent;
+import org.togetherjava.discord.server.execution.JShellWrapper;
 import sx.blah.discord.api.events.EventSubscriber;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
 import sx.blah.discord.handle.obj.IChannel;

--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -1,6 +1,7 @@
 package org.togetherjava.discord.server;
 
 import jdk.jshell.SnippetEvent;
+import org.togetherjava.discord.server.execution.JShellSessionManager;
 import org.togetherjava.discord.server.execution.JShellWrapper;
 import sx.blah.discord.api.events.EventSubscriber;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
@@ -8,18 +9,18 @@ import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.MessageBuilder;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EventHandler {
     private static final Pattern CODE_BLOCK_EXTRACTOR_PATTERN = Pattern.compile("```(java)?\\s*([\\w\\W]+)```");
 
-    private ConcurrentHashMap<String, JShellWrapper> sessions;
+    private JShellSessionManager jShellSessionManager;
     private final String botPrefix;
 
     public EventHandler(Config config) {
-        sessions = new ConcurrentHashMap<>();
+        jShellSessionManager = new JShellSessionManager(Duration.ofMinutes(15));
         botPrefix = config.getString("prefix");
     }
 
@@ -29,11 +30,7 @@ public class EventHandler {
         if (message.startsWith(botPrefix)) {
             String command = parseCommandFromMessage(message);
             String authorID = event.getAuthor().getStringID();
-            JShellWrapper shell = sessions.get(authorID);
-            if (shell == null) {
-                shell = new JShellWrapper();
-                sessions.put(authorID, shell);
-            }
+            JShellWrapper shell = jShellSessionManager.getSessionOrCreate(authorID);
 
             executeCommand(event.getAuthor(), shell, command, event.getChannel());
         }

--- a/src/main/java/org/togetherjava/discord/server/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/JShellWrapper.java
@@ -70,7 +70,7 @@ public class JShellWrapper {
 
         JShellResult(List<SnippetEvent> events, String stdout) {
             this.events = events;
-            this.stdout = stdout;
+            this.stdout = stdout == null ? "" : stdout;
         }
 
         public List<SnippetEvent> getEvents() {

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellSessionManager.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellSessionManager.java
@@ -1,0 +1,126 @@
+package org.togetherjava.discord.server.execution;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JShellSessionManager {
+
+    private static Logger LOGGER = LogManager.getLogger(JShellSessionManager.class);
+
+    private ConcurrentHashMap<String, SessionEntry> sessionMap;
+    private Duration timeToLive;
+
+    private Thread ticker;
+
+    public JShellSessionManager(Duration timeToLive) {
+        this.timeToLive = timeToLive;
+
+        this.sessionMap = new ConcurrentHashMap<>();
+
+        this.ticker = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                purgeOld();
+
+                try {
+                    Thread.sleep(timeToLive.dividedBy(2).toMillis());
+                } catch (InterruptedException e) {
+                    LOGGER.warn("Session housekeeper was interrupted", e);
+                    break;
+                }
+            }
+        }, "JShellSessionManager housekeeper");
+
+        this.ticker.start();
+    }
+
+    /**
+     * Returns the {@link JShellWrapper} for the user or creates a new.
+     *
+     * @param userId the id of the user
+     * @return the {@link JShellWrapper} to use
+     * @throws IllegalStateException if this manager was already shutdown via {@link #shutdown()}
+     */
+    public JShellWrapper getSessionOrCreate(String userId) {
+        if (ticker == null) {
+            throw new IllegalStateException("This manager was shutdown already.");
+        }
+        SessionEntry sessionEntry = sessionMap.computeIfAbsent(userId, s -> new SessionEntry(new JShellWrapper(), s));
+
+        return sessionEntry.getJShell();
+    }
+
+    /**
+     * Stops all activity of this manager (running thready, etx.) and frees its resources. You will no longer be able
+     * to get a {@link jdk.jshell.JShell} from this manager.
+     * <p>
+     * Should be called when the system is shut down.
+     */
+    public void shutdown() {
+        // FIXME: 11.04.18 Actually call this to release resources when the bot shuts down
+        ticker.interrupt();
+        ticker = null;
+        sessionMap.values().forEach(sessionEntry -> sessionEntry.getJShell().close());
+    }
+
+    /**
+     * Purges sessions that were inactive for longer than the specified threshold.
+     */
+    private void purgeOld() {
+        LOGGER.debug("Starting purge");
+        LocalDateTime now = LocalDateTime.now();
+
+        // A session could potentially be marked for removal, then another threads retrieves it and updates its
+        // last accessed state, leading to an unnecessary deletion. This should not have any impact on the caller
+        // though.
+        sessionMap.values().removeIf(sessionEntry -> {
+            Duration delta = Duration.between(now, sessionEntry.getLastAccess()).abs();
+
+            boolean tooOld = delta.compareTo(timeToLive) > 0;
+
+            if (tooOld) {
+                sessionEntry.getJShell().close();
+
+                LOGGER.debug(
+                        "Removed session for '{}', difference was '{}'",
+                        sessionEntry.getUserId(), delta
+                );
+            }
+
+            return tooOld;
+        });
+    }
+
+    private static class SessionEntry {
+        private JShellWrapper jshell;
+        private String userId;
+        private LocalDateTime lastAccess;
+
+        SessionEntry(JShellWrapper jshell, String userId) {
+            this.jshell = jshell;
+            this.userId = userId;
+            this.lastAccess = LocalDateTime.now();
+        }
+
+        /**
+         * Returns the {@link JShellWrapper} and sets the {@link #getLastAccess()} to now.
+         *
+         * @return the associated {@link JShellWrapper}
+         */
+        JShellWrapper getJShell() {
+            lastAccess = LocalDateTime.now();
+            return jshell;
+        }
+
+        LocalDateTime getLastAccess() {
+            return lastAccess;
+        }
+
+        String getUserId() {
+            return userId;
+        }
+    }
+}

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
@@ -42,6 +42,15 @@ public class JShellWrapper {
         }
     }
 
+    /**
+     * Closes the {@link JShell} session.
+     *
+     * @see JShell#close()
+     */
+    public void close() {
+        jShell.close();
+    }
+
     public JShellResult eval(String command) {
         try {
             return new JShellResult(evaluate(command), getStandardOut());

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
@@ -1,4 +1,4 @@
-package org.togetherjava.discord.server;
+package org.togetherjava.discord.server.execution;
 
 import jdk.jshell.JShell;
 import jdk.jshell.SnippetEvent;


### PR DESCRIPTION
* Fix the output being null if there was an exception without a message
* Move JShell to its own package
* Add a Session manager to close sessions after inactivity
* The SessionManager has a housekeeper thread that periodically checks
  whether it should remove JShellWrapper instances. If they are older
  than the passed time to live, they will be removed and their
  connection closed to free up resources. As a result they will also
  lose their history, i.e. methods and variables the user defined.
* Added a close method to the JShellWrapper which releases the held
  resources.