### PR TITLE
Fancier (error) messages and regex matching in the config

### DIFF
--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -5,6 +5,9 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 public class Config {
@@ -45,5 +48,16 @@ public class Config {
      */
     public String getString(String key) {
         return properties.getProperty(key);
+    }
+
+    /**
+     * Returns a property from the config splitting at {@code ","} and putting it in a list.
+     *
+     * @param key the key
+     * @return the property or an empty list if not found
+     */
+    public List<String> getCommaSeparatedList(String key) {
+        String value = getString(key);
+        return value == null ? Collections.emptyList() : Arrays.asList(value.split(","));
     }
 }

--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -20,7 +20,7 @@ public class EventHandler {
     private final String botPrefix;
 
     public EventHandler(Config config) {
-        jShellSessionManager = new JShellSessionManager(Duration.ofMinutes(15));
+        jShellSessionManager = new JShellSessionManager(Duration.ofMinutes(15), config);
         botPrefix = config.getString("prefix");
     }
 

--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -1,20 +1,28 @@
 package org.togetherjava.discord.server;
 
+import jdk.jshell.Snippet;
 import jdk.jshell.SnippetEvent;
+import org.apache.commons.lang3.StringUtils;
 import org.togetherjava.discord.server.execution.JShellSessionManager;
 import org.togetherjava.discord.server.execution.JShellWrapper;
 import sx.blah.discord.api.events.EventSubscriber;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IUser;
+import sx.blah.discord.util.EmbedBuilder;
 import sx.blah.discord.util.MessageBuilder;
 
+import java.awt.*;
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EventHandler {
     private static final Pattern CODE_BLOCK_EXTRACTOR_PATTERN = Pattern.compile("```(java)?\\s*([\\w\\W]+)```");
+    private static final Color ERROR_COLOR = new Color(255, 99, 71);
+    private static final Color SUCCESS_COLOR = new Color(118, 255, 0);
 
     private JShellSessionManager jShellSessionManager;
     private final String botPrefix;
@@ -49,51 +57,86 @@ public class EventHandler {
     }
 
     private void executeCommand(IUser user, JShellWrapper shell, String command, IChannel channel) {
-        JShellWrapper.JShellResult results = shell.eval(command);
+        try {
+            JShellWrapper.JShellResult results = shell.eval(command);
+            sendEvalResponse(results, shell, user, channel);
+        } catch (Throwable e) {
+            sendErrorResponse(user, channel, e);
+        }
+    }
 
-        for (SnippetEvent e : results.getEvents()) {
-            String errMsg = "";
-            if (e.exception() != null) {
-                errMsg = " | " + e.exception().getClass().getSimpleName() + ": " + e.exception().getMessage();
+    private void sendEvalResponse(JShellWrapper.JShellResult result, JShellWrapper shell, IUser user, IChannel channel) {
+        for (SnippetEvent snippetEvent : result.getEvents()) {
+            MessageBuilder messageBuilder = new MessageBuilder(channel.getClient())
+                    .withChannel(channel);
+
+            EmbedBuilder snippetResponse = buildSnippetResponse(snippetEvent, shell, user);
+
+            if (!result.getStdOut().isEmpty()) {
+                snippetResponse.appendField(
+                        "Output",
+                        StringUtils.truncate(result.getStdOut(), EmbedBuilder.FIELD_CONTENT_LIMIT),
+                        true
+                );
             }
 
-            sendSnippetResponse(user, command, channel, e.snippet().id(), e.value(), errMsg);
-        }
+            messageBuilder.withEmbed(snippetResponse.build());
 
-        if (!results.getStdOut().trim().isEmpty()) {
-            sendStandardOut(user, results.getStdOut(), channel);
+            messageBuilder.send();
         }
     }
 
-    private void sendSnippetResponse(IUser user, String command, IChannel channel, String id, String value, String error) {
-        MessageBuilder messageBuilder = new MessageBuilder(channel.getClient());
-        messageBuilder.withChannel(channel);
+    private EmbedBuilder buildSnippetResponse(SnippetEvent snippetEvent, JShellWrapper shell, IUser user) {
+        Snippet snippet = snippetEvent.snippet();
 
-        messageBuilder.appendContent(user.mention() + ": $" + id + ": ");
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .withColor(SUCCESS_COLOR)
+                .withTitle(user.getName() + "'s Result")
+                .appendField("Snippet-ID", "$" + snippet.id(), true)
+                .appendField(
+                        "Value",
+                        "`" + Objects.toString(snippetEvent.value()) + "`",
+                        true
+                );
 
-        if (command.contains("\n")) {
-            messageBuilder.appendCode("java", command);
-        } else {
-            messageBuilder.appendContent(command, MessageBuilder.Styles.INLINE_CODE);
+        if (snippetEvent.value() == null) {
+            shell.getSnippetDiagnostics(snippet).forEach(diag -> {
+                embedBuilder.appendField(
+                        "Error message",
+                        StringUtils.truncate(diag.getMessage(Locale.ENGLISH), EmbedBuilder.FIELD_CONTENT_LIMIT),
+                        true
+                );
+                embedBuilder.withColor(ERROR_COLOR);
+            });
         }
 
-        messageBuilder.appendContent(" = " + value + error);
+        if (snippetEvent.exception() != null) {
+            embedBuilder.appendField("Exception", snippetEvent.exception().getMessage(), true);
+            embedBuilder.withColor(ERROR_COLOR);
+        }
+
+        return embedBuilder;
+    }
+
+    private void sendErrorResponse(IUser user, IChannel channel, Throwable exception) {
+        MessageBuilder messageBuilder = new MessageBuilder(channel.getClient())
+                .withChannel(channel);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .withColor(ERROR_COLOR)
+                .withTitle(user.getName() + "'s Result");
+
+        embedBuilder.appendField("Type", exception.getClass().getSimpleName(), true);
+        embedBuilder.appendField("Message", "`" + exception.getMessage() + "'", true);
+
+        if (exception.getCause() != null) {
+            embedBuilder.appendField("Cause type", exception.getCause().getClass().getSimpleName(), true);
+            embedBuilder.appendField("Cause Message", "`" + exception.getCause().getMessage() + "'", true);
+        }
+
+        messageBuilder.withEmbed(embedBuilder.build());
 
         messageBuilder.send();
-    }
 
-    private void sendStandardOut(IUser user, String stdOut, IChannel channel) {
-        String truncated = stdOut;
-
-        if (truncated.length() > 1600) {
-            truncated = truncated.substring(0, 1600);
-        }
-
-        new MessageBuilder(channel.getClient())
-                .withChannel(channel)
-                .appendContent(user.mention() + ": ")
-                .appendContent("STD-OUT:\n", MessageBuilder.Styles.BOLD)
-                .appendQuote(truncated)
-                .send();
     }
 }

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellSessionManager.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellSessionManager.java
@@ -2,6 +2,7 @@ package org.togetherjava.discord.server.execution;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.togetherjava.discord.server.Config;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -13,11 +14,13 @@ public class JShellSessionManager {
 
     private ConcurrentHashMap<String, SessionEntry> sessionMap;
     private Duration timeToLive;
+    private Config config;
 
     private Thread ticker;
 
-    public JShellSessionManager(Duration timeToLive) {
+    public JShellSessionManager(Duration timeToLive, Config config) {
         this.timeToLive = timeToLive;
+        this.config = config;
 
         this.sessionMap = new ConcurrentHashMap<>();
 
@@ -48,7 +51,10 @@ public class JShellSessionManager {
         if (ticker == null) {
             throw new IllegalStateException("This manager was shutdown already.");
         }
-        SessionEntry sessionEntry = sessionMap.computeIfAbsent(userId, s -> new SessionEntry(new JShellWrapper(), s));
+        SessionEntry sessionEntry = sessionMap.computeIfAbsent(
+                userId,
+                s -> new SessionEntry(new JShellWrapper(config), s)
+        );
 
         return sessionEntry.getJShell();
     }

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
@@ -74,12 +74,26 @@ public class JShellWrapper {
         jShell.close();
     }
 
+    /**
+     * Evaluates a command and returns the resulting snippet events and stdout.
+     * <p>
+     * May throw an exception.
+     *
+     * @param command the command to run
+     * @return the result of running it
+     */
     public JShellResult eval(String command) {
-        try {
-            return new JShellResult(evaluate(command), getStandardOut());
-        } catch (Throwable e) {
-            return new JShellResult(List.of(), e.getMessage());
-        }
+        return new JShellResult(evaluate(command), getStandardOut());
+    }
+
+    /**
+     * Returns the diagnostics for the snippet. This includes things like compilation errors.
+     *
+     * @param snippet the snippet to return them for
+     * @return all found diagnostics
+     */
+    public Stream<Diag> getSnippetDiagnostics(Snippet snippet) {
+        return jShell.diagnostics(snippet);
     }
 
     private List<SnippetEvent> evaluate(String command) {

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
@@ -1,9 +1,13 @@
 package org.togetherjava.discord.server.execution;
 
+import jdk.jshell.Diag;
 import jdk.jshell.JShell;
+import jdk.jshell.Snippet;
 import jdk.jshell.SnippetEvent;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.togetherjava.discord.server.Config;
 import org.togetherjava.discord.server.io.StringOutputStream;
 import org.togetherjava.discord.server.sandbox.FilteredExecutionControlProvider;
 import org.togetherjava.discord.server.sandbox.Sandbox;
@@ -14,6 +18,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class JShellWrapper {
 
@@ -22,8 +28,10 @@ public class JShellWrapper {
     private JShell jShell;
     private StringOutputStream outputStream;
     private Sandbox sandbox;
+    private Config config;
 
-    public JShellWrapper() {
+    public JShellWrapper(Config config) {
+        this.config = config;
         this.outputStream = new StringOutputStream(Character.BYTES * 1600);
         this.jShell = buildJShell(outputStream);
         this.sandbox = new Sandbox();
@@ -31,15 +39,30 @@ public class JShellWrapper {
 
     private JShell buildJShell(OutputStream outputStream) {
         try {
+            PrintStream out = new PrintStream(outputStream, true, "UTF-8");
             return JShell.builder()
-                    .out(new PrintStream(outputStream, true, "UTF-8"))
-                    .executionEngine(new FilteredExecutionControlProvider(), Map.of())
+                    .out(out)
+                    .err(out)
+                    .executionEngine(getExecutionControlProvider(), Map.of())
                     .build();
         } catch (UnsupportedEncodingException e) {
             LOGGER.warn("Unsupported encoding: UTF-8. How?", e);
 
             return JShell.create();
         }
+    }
+
+    private FilteredExecutionControlProvider getExecutionControlProvider() {
+        return new FilteredExecutionControlProvider(
+                config.getCommaSeparatedList("blocked.packages"),
+                config.getCommaSeparatedList("blocked.classes"),
+                config.getCommaSeparatedList("blocked.methods").stream()
+                        .map(s -> {
+                            String[] parts = s.split("#");
+                            return new ImmutablePair<>(parts[0], parts[1]);
+                        })
+                        .collect(Collectors.toList())
+        );
     }
 
     /**

--- a/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
@@ -5,43 +5,53 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.objectweb.asm.*;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
 
 public class FilteredExecutionControl extends LocalExecutionControl {
 
-    private Set<Pair<String, String>> blockedMethods;
-    private Set<String> blockedPackages;
-    private Set<String> blockedClasses;
+    private final List<Pair<String, Pattern>> blockedMethods;
+    private final List<Pattern> blockedPackages;
+    private final List<Pattern> blockedClasses;
 
-    public FilteredExecutionControl() {
-        blockedMethods = new HashSet<>();
-        blockedPackages = new HashSet<>();
-        blockedClasses = new HashSet<>();
+    /**
+     * Creates a new {@link FilteredExecutionControl}.
+     *
+     * @param blockedPackages a collection with regular expressions for blocked packages
+     * @param blockedClasses  a collection with regular expressions for blocked classes
+     * @param blockedMethods  a collection in the form of {@code "ClassName -> Method regular expression"}
+     */
+    FilteredExecutionControl(Collection<String> blockedPackages, Collection<String> blockedClasses,
+                             Collection<Pair<String, String>> blockedMethods) {
 
-        blockPackage("java.lang.reflect");
-        blockPackage("java.lang.invoke");
-        blockClass("java.lang.ProcessBuilder");
-        blockClass("java.lang.ProcessHandle");
-        blockClass("java.lang.Runtime");
-        blockMethod("java.lang.reflect.Method", "invoke");
-        blockMethod("java.lang.System", "exit");
-        blockMethod("java.lang.Thread", "sleep");
-        blockMethod("java.lang.Thread", "wait");
-        blockMethod("java.lang.Thread", "notify");
-        blockMethod("java.lang.Thread", "currentThread");
+        this.blockedMethods = new ArrayList<>();
+        this.blockedPackages = new ArrayList<>();
+        this.blockedClasses = new ArrayList<>();
+
+        // TODO: Not really our job to parse that.
+        for (String packagePattern : blockedPackages) {
+            blockPackage(Pattern.compile(packagePattern));
+        }
+        for (String classPattern : blockedClasses) {
+            blockClass(Pattern.compile(classPattern));
+        }
+        for (Pair<String, String> pair : blockedMethods) {
+            blockMethod(pair.getKey(), Pattern.compile(pair.getValue()));
+        }
     }
 
-    public void blockMethod(String clazz, String methodName) {
+    private void blockMethod(String clazz, Pattern methodName) {
         blockedMethods.add(new ImmutablePair<>(clazz, methodName));
     }
 
-    public void blockPackage(String packageName) {
-        blockedPackages.add(packageName);
+    private void blockPackage(Pattern packagePattern) {
+        blockedPackages.add(packagePattern);
     }
 
-    public void blockClass(String clazz) {
-        blockedClasses.add(clazz);
+    private void blockClass(Pattern classPattern) {
+        blockedClasses.add(classPattern);
     }
 
 
@@ -61,6 +71,35 @@ public class FilteredExecutionControl extends LocalExecutionControl {
         super.load(cbcs);
     }
 
+    private boolean isClassBlocked(String name) {
+        return blockedClasses.stream().map(Pattern::asPredicate).anyMatch(pred -> pred.test(name));
+    }
+
+    private boolean isMethodBlocked(String className, String methodName) {
+        return blockedMethods.stream()
+                .filter(pair -> pair.getKey().equals(className))
+                .map(pair -> pair.getValue().asPredicate())
+                .anyMatch(pred -> pred.test(methodName));
+    }
+
+    private boolean isPackageBlocked(String packageName) {
+        return blockedPackages.stream().map(Pattern::asPredicate).anyMatch(pred -> pred.test(packageName));
+    }
+
+    private boolean isPackageOrParentBlocked(String sanitizedPackage) {
+        if (sanitizedPackage == null || sanitizedPackage.isEmpty()) {
+            return false;
+        }
+        if (isPackageBlocked(sanitizedPackage)) {
+            return true;
+        }
+
+        int nextDot = sanitizedPackage.lastIndexOf('.');
+
+        return nextDot >= 0 && isPackageOrParentBlocked(sanitizedPackage.substring(0, nextDot));
+    }
+
+
     private class FilteringMethodVisitor extends MethodVisitor {
         private FilteringMethodVisitor() {
             super(Opcodes.ASM6);
@@ -69,28 +108,15 @@ public class FilteredExecutionControl extends LocalExecutionControl {
         @Override
         public void visitMethodInsn(int opcode, String owner, String name, String descriptor,
                                     boolean isInterface) {
-            if (blockedClasses.contains(sanitizeClassName(owner))) {
+            if (isClassBlocked(sanitizeClassName(owner))) {
                 throw new UnsupportedOperationException("Naughty (class): " + owner);
             }
-            if (blockedMethods.contains(new ImmutablePair<>(sanitizeClassName(owner), name))) {
+            if (isMethodBlocked(sanitizeClassName(owner), name)) {
                 throw new UnsupportedOperationException("Naughty (meth): " + owner + "#" + name);
             }
             if (isPackageOrParentBlocked(sanitizeClassName(owner))) {
                 throw new UnsupportedOperationException("Naughty (pack): " + owner);
             }
-        }
-
-        private boolean isPackageOrParentBlocked(String sanitizedPackage) {
-            if (sanitizedPackage == null || sanitizedPackage.isEmpty()) {
-                return false;
-            }
-            if (blockedPackages.contains(sanitizedPackage)) {
-                return true;
-            }
-
-            int nextDot = sanitizedPackage.lastIndexOf('.');
-
-            return nextDot >= 0 && isPackageOrParentBlocked(sanitizedPackage.substring(0, nextDot));
         }
 
         private String sanitizeClassName(String owner) {

--- a/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControl.java
@@ -75,9 +75,22 @@ public class FilteredExecutionControl extends LocalExecutionControl {
             if (blockedMethods.contains(new ImmutablePair<>(sanitizeClassName(owner), name))) {
                 throw new UnsupportedOperationException("Naughty (meth): " + owner + "#" + name);
             }
-            if (blockedPackages.contains(sanitizeClassName(owner.substring(0, owner.lastIndexOf('/'))))) {
+            if (isPackageOrParentBlocked(sanitizeClassName(owner))) {
                 throw new UnsupportedOperationException("Naughty (pack): " + owner);
             }
+        }
+
+        private boolean isPackageOrParentBlocked(String sanitizedPackage) {
+            if (sanitizedPackage == null || sanitizedPackage.isEmpty()) {
+                return false;
+            }
+            if (blockedPackages.contains(sanitizedPackage)) {
+                return true;
+            }
+
+            int nextDot = sanitizedPackage.lastIndexOf('.');
+
+            return nextDot >= 0 && isPackageOrParentBlocked(sanitizedPackage.substring(0, nextDot));
         }
 
         private String sanitizeClassName(String owner) {

--- a/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlProvider.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlProvider.java
@@ -6,6 +6,7 @@ import jdk.jshell.spi.ExecutionControlProvider;
 import jdk.jshell.spi.ExecutionEnv;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
@@ -53,7 +54,12 @@ public class FilteredExecutionControlProvider implements ExecutionControlProvide
                 target.load((ExecutionControl.ClassBytecodes[]) args[0]);
             }
 
-            return method.invoke(hijackedExecutionControl, args);
+            // this unwrapping is necessary for JShell to detect that an exception it can handle was thrown
+            try {
+                return method.invoke(hijackedExecutionControl, args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
         }
     }
 }

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,1 +1,14 @@
 prefix=!jshell
+blocked.packages=sun,\
+                 jdk,\
+                 java.lang.reflect,\
+                 java.lang.invoke,\
+                 org.togetherjava
+blocked.classes=java.lang.ProcessBuilder,\
+                java.lang.ProcessHandle,\
+                java.lang.Runtime
+blocked.methods=java.lang.System#exit,\
+                java.lang.Thread#sleep,\
+                java.lang.Thread#wait,\
+                java.lang.Thread#notify,\
+                java.lang.Thread#currentThread

--- a/src/main/resources/bot.properties.example
+++ b/src/main/resources/bot.properties.example
@@ -1,2 +1,18 @@
 prefix=!jshell
 token=yourtokengoeshere
+
+blocked.packages=sun,\
+                 jdk,\
+                 java.lang.reflect,\
+                 java.lang.invoke,\
+                 org.togetherjava
+
+blocked.classes=java.lang.ProcessBuilder,\
+                java.lang.ProcessHandle,\
+                java.lang.Runtime
+
+blocked.methods=java.lang.System#exit,\
+                java.lang.Thread#sleep,\
+                java.lang.Thread#wait,\
+                java.lang.Thread#notify,\
+                java.lang.Thread#currentThread


### PR DESCRIPTION
## Blocking
* The blocked packages/classes/methods are now set in the config
* The blocked packages/classes/methods can now take Regular expressions
   as arguments
* Extend package blocks to block all subpackages too

## Nicer messages
* `System.err` is now captured alongside `System.out`
* Show compilation errors
* Show other error messages
* Use fancy embeds with a colored bar indicating the status and other goodies

## Misc
* Unwrap exceptions thrown inside JShell to make it easier for it to notice them
* The config can now return a comma separated list in a nicer format

## Closes
*Capture JShell compilation error output #5*

## Opens
*Handle output that is longer than 1024 characters #9*, as the maximum size was now reduced to 1024 (previously 2048)