### PR TITLE
Limit the time a computation can run for

### DIFF
--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +50,20 @@ public class Config {
      */
     public String getString(String key) {
         return properties.getProperty(key);
+    }
+
+    /**
+     * Tries to parse an entry in ISO-8601 duration format.
+     *
+     * @param key the key to look up
+     * @return the parsed duration or null if parsing was impossible.
+     */
+    public Duration getDuration(String key) {
+        try {
+            return Duration.parse(getString(key));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -12,8 +12,7 @@ import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.EmbedBuilder;
 import sx.blah.discord.util.MessageBuilder;
 
-import java.awt.*;
-import java.time.Duration;
+import java.awt.Color;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -28,8 +27,8 @@ public class EventHandler {
     private final String botPrefix;
 
     public EventHandler(Config config) {
-        jShellSessionManager = new JShellSessionManager(Duration.ofMinutes(15), config);
-        botPrefix = config.getString("prefix");
+        this.jShellSessionManager = new JShellSessionManager(config);
+        this.botPrefix = config.getString("prefix");
     }
 
     @EventSubscriber

--- a/src/main/java/org/togetherjava/discord/server/execution/AllottedTimeExceededException.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/AllottedTimeExceededException.java
@@ -1,0 +1,19 @@
+package org.togetherjava.discord.server.execution;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+import java.time.Duration;
+
+/**
+ * Indicates the the time you were allowed to use was exceeded.
+ */
+public class AllottedTimeExceededException extends RuntimeException {
+
+    public AllottedTimeExceededException(Duration maxTime) {
+        super(
+                "You exceeded the alloted time of '"
+                        + DurationFormatUtils.formatDurationWords(maxTime.toMillis(), true, true)
+                        + "'."
+        );
+    }
+}

--- a/src/main/java/org/togetherjava/discord/server/execution/TimeWatchdog.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/TimeWatchdog.java
@@ -1,0 +1,64 @@
+package org.togetherjava.discord.server.execution;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * Runs an action and cancels it if takes too long.
+ *
+ * <strong><em>This class is not thread safe and only one action may be running at a time.</em></strong>
+ */
+public class TimeWatchdog {
+
+    private static final Logger LOGGER = LogManager.getLogger(TimeWatchdog.class);
+
+    private final ScheduledExecutorService watchdogThreadPool;
+    private final Duration maxTime;
+    private final AtomicInteger operationCounter;
+
+    public TimeWatchdog(ScheduledExecutorService watchdogThreadPool, Duration maxTime) {
+        this.watchdogThreadPool = watchdogThreadPool;
+        this.maxTime = maxTime;
+        this.operationCounter = new AtomicInteger();
+    }
+
+    /**
+     * Runs an operation and cancels it if it takes too long.
+     *
+     * @param action       the action to run
+     * @param cancelAction cancels the passed action
+     * @param <T>          the type of the result of the operation
+     * @return the result of the operation
+     */
+    public <T> T runWatched(Supplier<T> action, Runnable cancelAction) {
+        AtomicBoolean killed = new AtomicBoolean(false);
+        int myId = operationCounter.incrementAndGet();
+
+        watchdogThreadPool.schedule(() -> {
+            // another calculation was done in the meantime.
+            if (myId != operationCounter.get()) {
+                return;
+            }
+
+            killed.set(true);
+
+            cancelAction.run();
+            LOGGER.debug("Killed a session (#" + myId + ")");
+        }, maxTime.toMillis(), TimeUnit.MILLISECONDS);
+
+        T result = action.get();
+
+        if (killed.get()) {
+            throw new AllottedTimeExceededException(maxTime);
+        }
+
+        return result;
+    }
+}

--- a/src/main/resources/bot.properties.example
+++ b/src/main/resources/bot.properties.example
@@ -1,5 +1,7 @@
 prefix=!jshell
 token=yourtokengoeshere
+session.ttl=PT15M
+computation.allotted_time=PT15S
 
 blocked.packages=sun,\
                  jdk,\


### PR DESCRIPTION
## Description
* Throw an AllottedTimeExceededException if an operation takes too long

* Use an independent Watchdog running on a shared threadpool to manage
  these timeouts. It doesn't run for long, so a few threads
  should probably suffice

* Added the session TTL and computation timeout to the config

### Note
**This adds two keys to the configuration.**