### PR TITLE
Add tests, fix a few bugs uncovered by them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ task fatJar(type: Jar) {
     with jar
 }
 
+
+test {
+    useJUnitPlatform()
+}
+
 repositories {
     mavenCentral()
     jcenter() //This prevents issues with transitive dependencies
@@ -33,7 +38,8 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    def junitVersion = '5.1.1'
+
     // https://mvnrepository.com/artifact/commons-daemon/commons-daemon
     compile group: 'commons-daemon', name: 'commons-daemon', version: '1.1.0'
     // Discord4J from Jitpack
@@ -49,4 +55,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12
     // todo once we fix the logging properties set this to compile
     testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.25'
+
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
 }

--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +50,20 @@ public class Config {
      */
     public String getString(String key) {
         return properties.getProperty(key);
+    }
+
+    /**
+     * Tries to parse an entry in ISO-8601 duration format.
+     *
+     * @param key the key to look up
+     * @return the parsed duration or null if parsing was impossible.
+     */
+    public Duration getDuration(String key) {
+        try {
+            return Duration.parse(getString(key));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -23,14 +23,20 @@ public class Config {
      * @throws IOException if an error occurs reading the config
      */
     public Config(Path configPath) throws IOException {
-        Properties defaults = new Properties();
-        loadFromStream(defaults, getClass().getResourceAsStream("/bot.properties"));
-
-        this.properties = new Properties(defaults);
+        this(new Properties());
 
         if (configPath != null && Files.exists(configPath)) {
             loadFromStream(properties, Files.newInputStream(configPath, StandardOpenOption.READ));
         }
+    }
+
+    /**
+     * Creates a config consisting of the given properties.
+     *
+     * @param properties the {@link Properties} to use
+     */
+    public Config(Properties properties) {
+        this.properties = new Properties(properties);
     }
 
     private void loadFromStream(Properties properties, InputStream stream) throws IOException {

--- a/src/main/java/org/togetherjava/discord/server/EventHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/EventHandler.java
@@ -12,8 +12,7 @@ import sx.blah.discord.handle.obj.IUser;
 import sx.blah.discord.util.EmbedBuilder;
 import sx.blah.discord.util.MessageBuilder;
 
-import java.awt.*;
-import java.time.Duration;
+import java.awt.Color;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -28,8 +27,8 @@ public class EventHandler {
     private final String botPrefix;
 
     public EventHandler(Config config) {
-        jShellSessionManager = new JShellSessionManager(Duration.ofMinutes(15), config);
-        botPrefix = config.getString("prefix");
+        this.jShellSessionManager = new JShellSessionManager(config);
+        this.botPrefix = config.getString("prefix");
     }
 
     @EventSubscriber

--- a/src/main/java/org/togetherjava/discord/server/execution/AllottedTimeExceededException.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/AllottedTimeExceededException.java
@@ -1,0 +1,19 @@
+package org.togetherjava.discord.server.execution;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+import java.time.Duration;
+
+/**
+ * Indicates the the time you were allowed to use was exceeded.
+ */
+public class AllottedTimeExceededException extends RuntimeException {
+
+    public AllottedTimeExceededException(Duration maxTime) {
+        super(
+                "You exceeded the alloted time of '"
+                        + DurationFormatUtils.formatDurationWords(maxTime.toMillis(), true, true)
+                        + "'."
+        );
+    }
+}

--- a/src/main/java/org/togetherjava/discord/server/execution/TimeWatchdog.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/TimeWatchdog.java
@@ -1,0 +1,64 @@
+package org.togetherjava.discord.server.execution;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * Runs an action and cancels it if takes too long.
+ *
+ * <strong><em>This class is not thread safe and only one action may be running at a time.</em></strong>
+ */
+public class TimeWatchdog {
+
+    private static final Logger LOGGER = LogManager.getLogger(TimeWatchdog.class);
+
+    private final ScheduledExecutorService watchdogThreadPool;
+    private final Duration maxTime;
+    private final AtomicInteger operationCounter;
+
+    public TimeWatchdog(ScheduledExecutorService watchdogThreadPool, Duration maxTime) {
+        this.watchdogThreadPool = watchdogThreadPool;
+        this.maxTime = maxTime;
+        this.operationCounter = new AtomicInteger();
+    }
+
+    /**
+     * Runs an operation and cancels it if it takes too long.
+     *
+     * @param action       the action to run
+     * @param cancelAction cancels the passed action
+     * @param <T>          the type of the result of the operation
+     * @return the result of the operation
+     */
+    public <T> T runWatched(Supplier<T> action, Runnable cancelAction) {
+        AtomicBoolean killed = new AtomicBoolean(false);
+        int myId = operationCounter.incrementAndGet();
+
+        watchdogThreadPool.schedule(() -> {
+            // another calculation was done in the meantime.
+            if (myId != operationCounter.get()) {
+                return;
+            }
+
+            killed.set(true);
+
+            cancelAction.run();
+            LOGGER.debug("Killed a session (#" + myId + ")");
+        }, maxTime.toMillis(), TimeUnit.MILLISECONDS);
+
+        T result = action.get();
+
+        if (killed.get()) {
+            throw new AllottedTimeExceededException(maxTime);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/togetherjava/discord/server/io/StringOutputStream.java
+++ b/src/main/java/org/togetherjava/discord/server/io/StringOutputStream.java
@@ -36,7 +36,7 @@ public class StringOutputStream extends OutputStream {
     public void write(int b) throws IOException {
         ensureCapacity();
 
-        if (size < buffer.length) {
+        if (size < buffer.length && size < maxSize) {
             buffer[size++] = (byte) b;
         }
     }

--- a/src/main/resources/bot.properties.example
+++ b/src/main/resources/bot.properties.example
@@ -1,5 +1,7 @@
 prefix=!jshell
 token=yourtokengoeshere
+session.ttl=PT15M
+computation.allotted_time=PT15S
 
 blocked.packages=sun,\
                  jdk,\

--- a/src/test/java/org/togetherjava/discord/server/execution/JShellSessionManagerTest.java
+++ b/src/test/java/org/togetherjava/discord/server/execution/JShellSessionManagerTest.java
@@ -1,0 +1,78 @@
+package org.togetherjava.discord.server.execution;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.togetherjava.discord.server.Config;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class JShellSessionManagerTest {
+
+    private JShellSessionManager jShellSessionManager;
+    private static Duration sessionTTL = Duration.ofSeconds(15);
+
+    @BeforeEach
+    void setUp() {
+        Properties properties = new Properties();
+        properties.setProperty("session.ttl", "PT15S");
+        properties.setProperty("computation.allotted_time", "PT15S");
+        Config config = new Config(properties);
+        jShellSessionManager = new JShellSessionManager(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jShellSessionManager.shutdown();
+    }
+
+    @Test
+    void cachesSessions() {
+        String userId = "1";
+        JShellWrapper session = jShellSessionManager.getSessionOrCreate(userId);
+        JShellWrapper secondCall = jShellSessionManager.getSessionOrCreate(userId);
+
+        assertEquals(session, secondCall, "Sessions differ");
+    }
+
+    @Test
+    void createsNewSessionForDifferentUser() {
+        JShellWrapper session = jShellSessionManager.getSessionOrCreate("1");
+        JShellWrapper secondCall = jShellSessionManager.getSessionOrCreate("2");
+
+        assertNotEquals(session, secondCall, "Sessions are the same");
+    }
+
+    @Test
+    void timesOutSessions() {
+        String userId = "1";
+        JShellWrapper session = jShellSessionManager.getSessionOrCreate(userId);
+
+        jShellSessionManager.setTimeProvider(() -> LocalDateTime.now().plus(sessionTTL).plusSeconds(5));
+        jShellSessionManager.purgeOld();
+
+        assertNotEquals(session, jShellSessionManager.getSessionOrCreate(userId), "Session was not expired");
+
+        // restore old
+        jShellSessionManager.setTimeProvider(LocalDateTime::now);
+    }
+
+    @Test
+    void cachesSessionsOverTime() {
+        String userId = "1";
+        JShellWrapper session = jShellSessionManager.getSessionOrCreate(userId);
+
+        jShellSessionManager.setTimeProvider(() -> LocalDateTime.now().plus(sessionTTL).minusSeconds(5));
+        jShellSessionManager.purgeOld();
+
+        assertEquals(session, jShellSessionManager.getSessionOrCreate(userId), "Session was expired");
+
+        // restore old
+        jShellSessionManager.setTimeProvider(LocalDateTime::now);
+    }
+}

--- a/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
+++ b/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
@@ -1,0 +1,87 @@
+package org.togetherjava.discord.server.execution;
+
+import jdk.jshell.Diag;
+import jdk.jshell.SnippetEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.togetherjava.discord.server.Config;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JShellWrapperTest {
+
+    private static JShellWrapper wrapper;
+
+    @BeforeAll
+    static void setupWrapper() {
+        Properties properties = new Properties();
+        properties.setProperty("blocked.packages", "java.time");
+        Config config = new Config(properties);
+        TimeWatchdog timeWatchdog = new TimeWatchdog(
+                Executors.newScheduledThreadPool(1),
+                Duration.ofMinutes(20)
+        );
+        wrapper = new JShellWrapper(config, timeWatchdog);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        wrapper.close();
+    }
+
+    @Test
+    void reportsCompileTimeError() {
+        JShellWrapper.JShellResult result = wrapper.eval("crazy stuff");
+
+        assertFalse(result.getEvents().isEmpty(), "Found no events");
+
+        for (SnippetEvent snippetEvent : result.getEvents()) {
+            List<Diag> diags = wrapper.getSnippetDiagnostics(snippetEvent.snippet()).collect(Collectors.toList());
+            assertFalse(diags.isEmpty(), "Has no diagnostics");
+            assertTrue(diags.get(0).isError(), "Diagnostic is no error");
+        }
+    }
+
+    @Test
+    void correctlyComputesExpression() {
+        JShellWrapper.JShellResult result = wrapper.eval("1+1");
+
+        assertEquals(result.getEvents().size(), 1, "Event count is not 1");
+
+        SnippetEvent snippetEvent = result.getEvents().get(0);
+
+        assertNull(snippetEvent.exception(), "An exception occurred");
+
+        assertEquals("2", snippetEvent.value(), "Calculation was wrong");
+    }
+
+    @Test
+    void savesHistory() {
+        wrapper.eval("int test = 1+1;");
+        JShellWrapper.JShellResult result = wrapper.eval("test");
+
+        assertEquals(result.getEvents().size(), 1, "Event count is not 1");
+
+        SnippetEvent snippetEvent = result.getEvents().get(0);
+
+        assertNull(snippetEvent.exception(), "An exception occurred");
+
+        assertEquals("2", snippetEvent.value(), "Calculation was wrong");
+    }
+
+    @Test
+    void blocksPackage() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> wrapper.eval("java.time.LocalDateTime.now()"),
+                "No exception was thrown when accessing a blocked package."
+        );
+    }
+}

--- a/src/test/java/org/togetherjava/discord/server/io/StringOutputStreamTest.java
+++ b/src/test/java/org/togetherjava/discord/server/io/StringOutputStreamTest.java
@@ -1,0 +1,52 @@
+package org.togetherjava.discord.server.io;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringOutputStreamTest {
+
+    @Test
+    void capturesOutput() throws IOException {
+        String test = "hello world";
+        checkToString(test, test, test.length(), Integer.MAX_VALUE);
+    }
+
+    @Test
+    void truncates() throws IOException {
+        checkToString("hello", "hell", 5, 4);
+    }
+
+    @Test
+    void survivesBufferExpansion() throws IOException {
+        final int length = 10_000;
+        String test = StringUtils.repeat("A", length);
+
+        checkToString(test, test, length, Integer.MAX_VALUE);
+    }
+
+    @Test
+    void survivesBufferExpansionAndTruncates() throws IOException {
+        final int length = 10_000;
+        String test = StringUtils.repeat("A", length);
+        String expected = StringUtils.repeat("A", 4000);
+
+        checkToString(test, expected, length, 4_000);
+    }
+
+    private void checkToString(String input, String expected, int byteCount, int maxSize) throws IOException {
+        StringOutputStream stringOutputStream = new StringOutputStream(maxSize);
+
+        byte[] bytes = input.getBytes(StandardCharsets.US_ASCII);
+
+        assertEquals(byteCount, bytes.length, "Somehow ASCII has changed?");
+
+        stringOutputStream.write(bytes);
+
+        assertEquals(expected, stringOutputStream.toString(), "Stored output differed.");
+    }
+}

--- a/src/test/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlTest.java
+++ b/src/test/java/org/togetherjava/discord/server/sandbox/FilteredExecutionControlTest.java
@@ -1,0 +1,113 @@
+package org.togetherjava.discord.server.sandbox;
+
+import jdk.jshell.JShell;
+import jdk.jshell.SnippetEvent;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FilteredExecutionControlTest {
+
+    @Test
+    void testBlockPackage() {
+        JShell jshell = getJShell(List.of("java.time"), List.of(), List.of());
+
+        assertTrue(
+                failed(jshell, "java.time.LocalDateTime.now()"),
+                "Was able to access a method in the blocked package."
+        );
+        assertTrue(
+                failed(jshell, "java.time.format.DateTimeFormatter.ISO_DATE"),
+                "Was able to access a field in a subpackage of a blocked package."
+        );
+        assertTrue(
+                failed(jshell, "java.time.format.DateTimeFormatter.ISO_DATE.getChronology()"),
+                "Was able to access a method in a subpackage of a blocked package."
+        );
+        assertFalse(
+                failed(jshell, "Math.PI"),
+                "Was not able to access a field in another package."
+        );
+        assertFalse(
+                failed(jshell, "Math.abs(5)"),
+                "Was not able to access a field in another package."
+        );
+    }
+
+    @Test
+    void testBlockClass() {
+        JShell jshell = getJShell(List.of(), List.of("java.time.LocalDate"), List.of());
+
+        assertTrue(
+                failed(jshell, "java.time.LocalDate.now()"),
+                "Was able to access a method in the blocked class."
+        );
+        assertFalse(
+                failed(jshell, "java.time.LocalDateTime.now()"),
+                "Was not able to access another class with the same prefix."
+        );
+        assertFalse(
+                failed(jshell, "java.time.format.DateTimeFormatter.ISO_DATE"),
+                "Was not able to access a field in a not blocked class."
+        );
+        assertFalse(
+                failed(jshell, "java.time.format.DateTimeFormatter.ISO_DATE.getChronology()"),
+                "Was not able to access a method in a not blocked class."
+        );
+    }
+
+    @Test
+    void testBlockMethod() {
+        JShell jshell = getJShell(
+                List.of(), List.of(),
+                List.of(
+                        new ImmutablePair<>("java.time.LocalDate", "now")
+                )
+        );
+
+        assertTrue(
+                failed(jshell, "java.time.LocalDate.now()"),
+                "Was able to access a blocked method."
+        );
+        assertFalse(
+                failed(jshell, "java.time.LocalDateTime.now()"),
+                "Was not able to access a method with the same name."
+        );
+        assertFalse(
+                failed(jshell, "Math.abs(5)"),
+                "Was not able to access a method in a not blocked class."
+        );
+        assertFalse(
+                failed(jshell, "java.time.format.DateTimeFormatter.ISO_DATE.getChronology()"),
+                "Was not able to access a method in a not blocked class."
+        );
+    }
+
+    private JShell getJShell(Collection<String> blockedPackages, Collection<String> blockedClasses,
+                             Collection<Pair<String, String>> blockedMethods) {
+        return JShell.builder()
+                .executionEngine(
+                        new FilteredExecutionControlProvider(blockedPackages, blockedClasses, blockedMethods),
+                        Map.of()
+                )
+                .build();
+    }
+
+    private boolean failed(JShell jshell, String command) {
+        try {
+            for (SnippetEvent event : jshell.eval(command)) {
+                System.out.println("Got a value: " + event.value());
+            }
+        } catch (UnsupportedOperationException e) {
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
* Added some tests

* Fixed a bug in the StringOutputStream which led to it not truncating
  the input if the buffer was big enough.

* Made the time in the JShellSessionManager testable

* Made the FilteredExecutionControl use `Pattern.match` instead of
  `Pattern.find` to not block unrelated packages.

* Made the config load from passed `Properties` to make it easier
  testable