### PR TITLE
Add a configurable startup command to initialize each JShell session

### DIFF
--- a/src/main/java/org/togetherjava/discord/server/Config.java
+++ b/src/main/java/org/togetherjava/discord/server/Config.java
@@ -58,6 +58,17 @@ public class Config {
   }
 
   /**
+   * Returns a property from the config as a String.
+   *
+   * @param key the key
+   * @param defaultValue the default value to use when the key does not exist
+   * @return the property or null if not found
+   */
+  public String getStringOrDefault(String key, String defaultValue) {
+    return properties.getProperty(key, defaultValue);
+  }
+
+  /**
    * Tries to parse an entry in ISO-8601 duration format.
    *
    * @param key the key to look up

--- a/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
+++ b/src/main/java/org/togetherjava/discord/server/execution/JShellWrapper.java
@@ -27,7 +27,11 @@ public class JShellWrapper {
   public JShellWrapper(Config config, TimeWatchdog watchdog) {
     this.watchdog = watchdog;
     this.outputStream = new StringOutputStream(Character.BYTES * 1600);
+
     this.jShell = buildJShell(outputStream, config);
+
+    // Initialize JShell using the startup command
+    jShell.eval(config.getStringOrDefault("java.startup-command", ""));
   }
 
   private JShell buildJShell(OutputStream outputStream, Config config) {

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -27,3 +27,14 @@ blocked.methods=java.lang.System#exit,\
                 java.lang.Thread#wait,\
                 java.lang.Thread#notify,\
                 java.lang.Thread#currentThread
+# Commands JShell runs when starting up.
+java.startup-command=import java.io.*;\
+                import java.math.*;\
+                import java.net.*;\
+                import java.nio.file.*;\
+                import java.util.*;\
+                import java.util.concurrent.*;\
+                import java.util.function.*;\
+                import java.util.prefs.*;\
+                import java.util.regex.*;\
+                import java.util.stream.*;


### PR DESCRIPTION
## Motivation
It is intended mainly to provide a way to automatically import certain packages for each started session.

## Current usage
Currently used to mimic the default JShell imports, which make it a lot more convenient to use.