### PR TITLE
Fix security manager checks not being executed properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit-jupiter.version>5.3.2</junit-jupiter.version>
   </properties>
 
   <build>
@@ -116,13 +117,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.3.1</version>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.3.1</version>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/togetherjava/discord/server/sandbox/JshellSecurityManager.java
+++ b/src/main/java/org/togetherjava/discord/server/sandbox/JshellSecurityManager.java
@@ -3,11 +3,14 @@ package org.togetherjava.discord.server.sandbox;
 import java.security.Permission;
 import java.util.Arrays;
 
+/**
+ * The {@link SecurityManager} used to limit JShell's permissions.
+ */
 public class JshellSecurityManager extends SecurityManager {
 
   @Override
   public void checkPermission(Permission perm) {
-    if (!comesFromBotCode()) {
+    if (comesFromMe()) {
       return;
     }
 
@@ -27,10 +30,13 @@ public class JshellSecurityManager extends SecurityManager {
         .anyMatch(aClass -> aClass.getName().contains("REPL"));
   }
 
-  private boolean comesFromBotCode() {
+  private boolean comesFromMe() {
     return Arrays.stream(getClassContext())
+        // one frame for this method, one frame for the call to checkPermission
         .skip(2)
-        .anyMatch(aClass -> aClass == getClassContext()[0]);
+        // see if the security manager appears anywhere else in the context. If so, we initiated
+        // the call
+        .anyMatch(aClass -> aClass == getClass());
   }
 
   private boolean containsClass(String name) {

--- a/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
+++ b/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
@@ -1,87 +1,143 @@
 package org.togetherjava.discord.server.execution;
 
-import jdk.jshell.Diag;
-import jdk.jshell.SnippetEvent;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.togetherjava.discord.server.Config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
+import jdk.jshell.Diag;
+import jdk.jshell.Snippet.Status;
+import jdk.jshell.SnippetEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.togetherjava.discord.server.Config;
+import org.togetherjava.discord.server.execution.JShellWrapper.JShellResult;
 
 class JShellWrapperTest {
 
-    private static JShellWrapper wrapper;
+  private static JShellWrapper wrapper;
 
-    @BeforeAll
-    static void setupWrapper() {
-        Properties properties = new Properties();
-        properties.setProperty("blocked.packages", "java.time");
-        Config config = new Config(properties);
-        TimeWatchdog timeWatchdog = new TimeWatchdog(
-                Executors.newScheduledThreadPool(1),
-                Duration.ofMinutes(20)
+  @BeforeAll
+  static void setupWrapper() {
+    Properties properties = new Properties();
+    properties.setProperty("blocked.packages", "java.time");
+    Config config = new Config(properties);
+    TimeWatchdog timeWatchdog = new TimeWatchdog(
+        Executors.newScheduledThreadPool(1),
+        Duration.ofMinutes(20)
+    );
+    wrapper = new JShellWrapper(config, timeWatchdog);
+  }
+
+  @AfterAll
+  static void cleanup() {
+    wrapper.close();
+  }
+
+  @Test
+  void reportsCompileTimeError() {
+    JShellWrapper.JShellResult result = wrapper.eval("crazy stuff");
+
+    assertFalse(result.getEvents().isEmpty(), "Found no events");
+
+    for (SnippetEvent snippetEvent : result.getEvents()) {
+      List<Diag> diags = wrapper.getSnippetDiagnostics(snippetEvent.snippet())
+          .collect(Collectors.toList());
+      assertFalse(diags.isEmpty(), "Has no diagnostics");
+      assertTrue(diags.get(0).isError(), "Diagnostic is no error");
+    }
+  }
+
+  @Test
+  void correctlyComputesExpression() {
+    JShellWrapper.JShellResult result = wrapper.eval("1+1");
+
+    assertEquals(result.getEvents().size(), 1, "Event count is not 1");
+
+    SnippetEvent snippetEvent = result.getEvents().get(0);
+
+    assertNull(snippetEvent.exception(), "An exception occurred");
+
+    assertEquals("2", snippetEvent.value(), "Calculation was wrong");
+  }
+
+  @Test
+  void savesHistory() {
+    wrapper.eval("int test = 1+1;");
+    JShellWrapper.JShellResult result = wrapper.eval("test");
+
+    assertEquals(result.getEvents().size(), 1, "Event count is not 1");
+
+    SnippetEvent snippetEvent = result.getEvents().get(0);
+
+    assertNull(snippetEvent.exception(), "An exception occurred");
+
+    assertEquals("2", snippetEvent.value(), "Calculation was wrong");
+  }
+
+  @Test
+  void blocksPackage() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> wrapper.eval("java.time.LocalDateTime.now()"),
+        "No exception was thrown when accessing a blocked package."
+    );
+  }
+
+  @ParameterizedTest(name = "Accessing \"{0}\" should fail")
+  @ValueSource(strings = {
+      "/opt",
+      "~",
+      "/tmp/"
+  })
+  void blocksFileAccess(String fileName) {
+    JShellResult result = wrapper.eval("new java.io.File(\"" + fileName + "\").listFiles()");
+
+    if (!allFailed(result)) {
+      printSnippetResult(result);
+    }
+
+    assertTrue(
+        allFailed(result),
+        "Not all snippets were rejected when accessing a file."
+    );
+  }
+
+  @Test
+  void blocksNetworkIo() {
+    JShellResult result = wrapper
+        .eval("new java.net.URL(\"https://duckduckgo.com\").openConnection().connect()");
+
+    if (!allFailed(result)) {
+      printSnippetResult(result);
+    }
+
+    assertTrue(
+        allFailed(result),
+        "Not all snippets were rejected when doing network I/O."
+    );
+  }
+
+  private boolean allFailed(JShellResult result) {
+    return result.getEvents().stream()
+        .allMatch(snippetEvent ->
+            snippetEvent.status() == Status.REJECTED
+                || snippetEvent.exception() != null
         );
-        wrapper = new JShellWrapper(config, timeWatchdog);
+  }
+
+  private void printSnippetResult(JShellResult result) {
+    for (SnippetEvent event : result.getEvents()) {
+      System.out.println(event);
     }
-
-    @AfterAll
-    static void cleanup() {
-        wrapper.close();
-    }
-
-    @Test
-    void reportsCompileTimeError() {
-        JShellWrapper.JShellResult result = wrapper.eval("crazy stuff");
-
-        assertFalse(result.getEvents().isEmpty(), "Found no events");
-
-        for (SnippetEvent snippetEvent : result.getEvents()) {
-            List<Diag> diags = wrapper.getSnippetDiagnostics(snippetEvent.snippet()).collect(Collectors.toList());
-            assertFalse(diags.isEmpty(), "Has no diagnostics");
-            assertTrue(diags.get(0).isError(), "Diagnostic is no error");
-        }
-    }
-
-    @Test
-    void correctlyComputesExpression() {
-        JShellWrapper.JShellResult result = wrapper.eval("1+1");
-
-        assertEquals(result.getEvents().size(), 1, "Event count is not 1");
-
-        SnippetEvent snippetEvent = result.getEvents().get(0);
-
-        assertNull(snippetEvent.exception(), "An exception occurred");
-
-        assertEquals("2", snippetEvent.value(), "Calculation was wrong");
-    }
-
-    @Test
-    void savesHistory() {
-        wrapper.eval("int test = 1+1;");
-        JShellWrapper.JShellResult result = wrapper.eval("test");
-
-        assertEquals(result.getEvents().size(), 1, "Event count is not 1");
-
-        SnippetEvent snippetEvent = result.getEvents().get(0);
-
-        assertNull(snippetEvent.exception(), "An exception occurred");
-
-        assertEquals("2", snippetEvent.value(), "Calculation was wrong");
-    }
-
-    @Test
-    void blocksPackage() {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> wrapper.eval("java.time.LocalDateTime.now()"),
-                "No exception was thrown when accessing a blocked package."
-        );
-    }
+  }
 }

--- a/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
+++ b/src/test/java/org/togetherjava/discord/server/execution/JShellWrapperTest.java
@@ -127,6 +127,21 @@ class JShellWrapperTest {
     );
   }
 
+  @Test
+  void blocksResettingSecurityManager() {
+    JShellResult result = wrapper
+        .eval("System.setSecurityManager(null)");
+
+    if (!allFailed(result)) {
+      printSnippetResult(result);
+    }
+
+    assertTrue(
+        allFailed(result),
+        "Not all snippets were rejected when resetting the security manager."
+    );
+  }
+
   private boolean allFailed(JShellResult result) {
     return result.getEvents().stream()
         .allMatch(snippetEvent ->


### PR DESCRIPTION
## Problem
The security manager wrongly thought almost every access was initiated by itself, resulting in it being way too lenient.

## Closes
#22 Unfiltered file access

## Resolution
Fix the security manager believing calls originated from itself and add some small regression tests for this case.

## Future possible problems
Checking whether the security manager appears in the callstack might be problematic, if a malicious user is able to inject it in there. Not quite sure if that is possible, but it is not ideal. I am more than happy to receive some nicer solution or hints, if anybody has some.

#### Addendum
For some reason, the test files were formatted with a different formatter, so the diff of that file is basically useless. The last two methods are new.