### PR TITLE
35 migrate to jda 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <release>10</release>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>3.7.1_422</version>
+      <version>4.2.0_214</version>
     </dependency>
 
     <!--OTHER-->

--- a/src/main/java/org/togetherjava/discord/server/CommandHandler.java
+++ b/src/main/java/org/togetherjava/discord/server/CommandHandler.java
@@ -8,14 +8,14 @@ import java.util.regex.Pattern;
 import jdk.jshell.Diag;
 import jdk.jshell.Snippet;
 import jdk.jshell.SnippetEvent;
-import net.dv8tion.jda.core.EmbedBuilder;
-import net.dv8tion.jda.core.MessageBuilder;
-import net.dv8tion.jda.core.entities.Message;
-import net.dv8tion.jda.core.entities.MessageChannel;
-import net.dv8tion.jda.core.entities.User;
-import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.core.hooks.ListenerAdapter;
-import net.dv8tion.jda.core.requests.RestAction;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.RestAction;
 import org.togetherjava.discord.server.execution.AllottedTimeExceededException;
 import org.togetherjava.discord.server.execution.JShellSessionManager;
 import org.togetherjava.discord.server.execution.JShellWrapper;
@@ -94,7 +94,7 @@ public class CommandHandler extends ListenerAdapter {
   }
 
   private void handleResult(User user, JShellWrapper.JShellResult result, JShellWrapper shell,
-      MessageChannel channel) {
+                            MessageChannel channel) {
     MessageBuilder messageBuilder = new MessageBuilder();
     EmbedBuilder embedBuilder;
 

--- a/src/main/java/org/togetherjava/discord/server/JShellBot.java
+++ b/src/main/java/org/togetherjava/discord/server/JShellBot.java
@@ -4,9 +4,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import net.dv8tion.jda.core.AccountType;
-import net.dv8tion.jda.core.JDA;
-import net.dv8tion.jda.core.JDABuilder;
+
+import net.dv8tion.jda.api.AccountType;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,10 +34,10 @@ public class JShellBot {
       System.exit(2);
     }
 
-    JDA jda = new JDABuilder(AccountType.BOT)
-        .setToken(config.getString("token"))
-        .addEventListener(new CommandHandler(config))
-        .build();
+    JDA jda = JDABuilder.createDefault(config.getString("token"))
+            .setDisabledIntents(GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_PRESENCES)
+            .addEventListeners(new CommandHandler(config))
+            .build();
     jda.awaitReady();
 
     LOGGER.info("Goliath Online");

--- a/src/main/java/org/togetherjava/discord/server/JShellBot.java
+++ b/src/main/java/org/togetherjava/discord/server/JShellBot.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;

--- a/src/main/java/org/togetherjava/discord/server/rendering/CompilationErrorRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/CompilationErrorRenderer.java
@@ -2,8 +2,8 @@ package org.togetherjava.discord.server.rendering;
 
 import java.util.Locale;
 import jdk.jshell.Diag;
-import net.dv8tion.jda.core.EmbedBuilder;
-import net.dv8tion.jda.core.entities.MessageEmbed;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 
 /**
  * Renders error messages.

--- a/src/main/java/org/togetherjava/discord/server/rendering/ExceptionRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/ExceptionRenderer.java
@@ -3,7 +3,7 @@ package org.togetherjava.discord.server.rendering;
 import java.util.Objects;
 import jdk.jshell.EvalException;
 import jdk.jshell.Snippet.Status;
-import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.api.EmbedBuilder;
 
 /**
  * A renderer for exceptions.

--- a/src/main/java/org/togetherjava/discord/server/rendering/RejectedColorRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/RejectedColorRenderer.java
@@ -2,7 +2,7 @@ package org.togetherjava.discord.server.rendering;
 
 import jdk.jshell.Snippet.Status;
 import jdk.jshell.SnippetEvent;
-import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.api.EmbedBuilder;
 import org.togetherjava.discord.server.execution.JShellWrapper;
 
 /**

--- a/src/main/java/org/togetherjava/discord/server/rendering/RenderUtils.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/RenderUtils.java
@@ -4,7 +4,6 @@ package org.togetherjava.discord.server.rendering;
 import java.awt.Color;
 import jdk.jshell.Snippet;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.core.EmbedBuilder;
 
 /**
  * Contains utility functions for rendering.

--- a/src/main/java/org/togetherjava/discord/server/rendering/RenderUtils.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/RenderUtils.java
@@ -3,6 +3,7 @@ package org.togetherjava.discord.server.rendering;
 
 import java.awt.Color;
 import jdk.jshell.Snippet;
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.core.EmbedBuilder;
 
 /**

--- a/src/main/java/org/togetherjava/discord/server/rendering/Renderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/Renderer.java
@@ -1,6 +1,6 @@
 package org.togetherjava.discord.server.rendering;
 
-import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.api.EmbedBuilder;
 
 /**
  * A renderer takes care of displaying some message in an embed.

--- a/src/main/java/org/togetherjava/discord/server/rendering/RendererManager.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/RendererManager.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import jdk.jshell.Snippet.Status;
 import jdk.jshell.SnippetEvent;
-import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.api.EmbedBuilder;
 import org.togetherjava.discord.server.execution.JShellWrapper;
 
 /**

--- a/src/main/java/org/togetherjava/discord/server/rendering/StandardOutputRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/StandardOutputRenderer.java
@@ -1,8 +1,7 @@
 package org.togetherjava.discord.server.rendering;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.core.EmbedBuilder;
-import net.dv8tion.jda.core.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.togetherjava.discord.server.execution.JShellWrapper;
 
 /**

--- a/src/main/java/org/togetherjava/discord/server/rendering/StandardOutputRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/StandardOutputRenderer.java
@@ -1,5 +1,6 @@
 package org.togetherjava.discord.server.rendering;
 
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.entities.MessageEmbed;
 import org.togetherjava.discord.server.execution.JShellWrapper;

--- a/src/main/java/org/togetherjava/discord/server/rendering/StringCatchallRenderer.java
+++ b/src/main/java/org/togetherjava/discord/server/rendering/StringCatchallRenderer.java
@@ -1,8 +1,9 @@
 package org.togetherjava.discord.server.rendering;
 
 import java.util.Objects;
-import net.dv8tion.jda.core.EmbedBuilder;
-import net.dv8tion.jda.core.entities.MessageEmbed;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 
 /**
  * A renderer for results that just renders whatever hasn't been renderer yet as a string.

--- a/src/test/java/org/togetherjava/discord/server/rendering/TruncationRendererTest.java
+++ b/src/test/java/org/togetherjava/discord/server/rendering/TruncationRendererTest.java
@@ -2,7 +2,7 @@ package org.togetherjava.discord.server.rendering;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import net.dv8tion.jda.core.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
- Updates code to utilize JDA version 4.2.0_234.
- Uses new JDA build function. 

The existing build function is deprecated. 
JDA also no longer supports AccountType.CLIENT and .BOT is enabled by default it seems.